### PR TITLE
Switch to Qt5 and MSVC toolchain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,7 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(QT NAMES Qt6 REQUIRED COMPONENTS Widgets Charts SerialPort)
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets Charts SerialPort)
+find_package(Qt5 REQUIRED COMPONENTS Core Widgets Charts SerialPort Bluetooth)
 
 set(VERSION_FILE "${CMAKE_CURRENT_BINARY_DIR}/include/version.h")
 include_directories("${CMAKE_CURRENT_BINARY_DIR}/include")
@@ -20,8 +19,7 @@ include_directories("${CMAKE_CURRENT_BINARY_DIR}/include")
 # Glob source files.
 file(GLOB_RECURSE PROJECT_SOURCES LIST_DIRECTORIES false "src/*.cpp" "src/*.h" "src/*.qrc" "src/*.ui")
 
-qt_add_executable(linescaleGUI
-    MANUAL_FINALIZATION
+add_executable(linescaleGUI
     ${PROJECT_SOURCES}
     "${VERSION_FILE}"
 )
@@ -37,20 +35,21 @@ add_custom_target(VersionFile ALL
 include(tools/cmake/version.cmake)
 
 target_link_libraries(linescaleGUI PRIVATE
+    Qt${QT_VERSION_MAJOR}::Core
     Qt${QT_VERSION_MAJOR}::Widgets
     Qt${QT_VERSION_MAJOR}::Charts
-    Qt${QT_VERSION_MAJOR}::SerialPort)
+    Qt${QT_VERSION_MAJOR}::SerialPort
+    Qt${QT_VERSION_MAJOR}::Bluetooth)
 
 set_target_properties(linescaleGUI PROPERTIES
     MACOSX_BUNDLE_GUI_IDENTIFIER linegrip.com
     MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
     MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
     MACOSX_BUNDLE TRUE
-
     # WIN32_EXECUTABLE TRUE # Comment for std::cout and qDebug
 )
 
-qt_finalize_executable(linescaleGUI)
+# qt_finalize_executable(linescaleGUI)
 include(tools/cmake/windeployqt.cmake)
 
 if(WIN32)

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ A cross platform GUI to interact with the [LineScale 3](https://www.linegrip.com
    recommended extensions.)
     - CMake Tools
     - C/C++
-3. Configure CMake kits
-    - **Windows**
+3. Platform-specific setup
+    <!-- - **Windows GNU**
         1. `Ctrl+P`→ `CMake: Edit User-Local CMake Kits`
         2. Add the following kit:
            ```json
@@ -27,7 +27,25 @@ A cross platform GUI to interact with the [LineScale 3](https://www.linegrip.com
                 }
             }
            ```
-        3. Select the new kit.
-    - **Unix**: TBD
+        3. Select the new kit. -->
+    - **Windows MSVC**
+        1. Install [Visual Studio Build
+           Tools](https://visualstudio.microsoft.com/de/downloads/#build-tools-for-visual-studio-2022)
+           (`Windows SDK` and `MSVC - VS 2019`).
+        2. Install `Qt 5.15` including `MSVC 2019`.
+        3. Set the environment variable `QT_DIR` to `<Qt Install dir>/5.15.2/msvc2019_64`.  
+           This can be done by adding
+           ```json
+            "cmake.environment": {
+                "QT_DIR": "C:/Users/n3xed/qt/5.15.2/msvc2019_64"
+            },
+           ```
+           to the vscode settings, or adding that variable globally in Windows.
+        4. Open the cloned repository in vscode.
+        5. `Ctrl+P`→ `CMake: Scan for Kits`  
+           Some Visual Studio Kits should have been discovered.
+        6. Select the appropriate kit (e.g. `Visual Studio Build Tools 2022 Release - amd64`).
+    - **Linux**: TBD
+    - **MacOS**: TBD
 4. Configure the project.
 5. Build the project.

--- a/tools/cmake/windeployqt.cmake
+++ b/tools/cmake/windeployqt.cmake
@@ -1,9 +1,9 @@
-find_package(Qt6Core REQUIRED)
+find_package(Qt5Core REQUIRED)
 
 function(windeployqt target)
 
     # get absolute path to qmake, then use it to find windeployqt executable
-    get_target_property(_qmake_executable Qt6::qmake IMPORTED_LOCATION)
+    get_target_property(_qmake_executable Qt5::qmake IMPORTED_LOCATION)
     get_filename_component(_qt_bin_dir "${_qmake_executable}" DIRECTORY)
 
     # POST_BUILD step


### PR DESCRIPTION
Switching to Qt5 for Windows 7 support.

Although as per [Qt Bluetooth Docs](https://doc.qt.io/Qt-5/qtbluetooth-index.html), Qt5 only supports Bluetooth LE for Windows 8 and newer, and only if the `win32` backend is explicitly enabled through a CLI argument (presumably for qmake). However, it does not say how this is done for CMake. Since the LineScale 3 *needs* Bluetooth LE we could either:
- Support Bluetooth connections only for Windows 10 and newer.
- Support Bluetooth connections for Windows 8 and figure out how to enable the native backend (maybe it is already somehow?).

Document build setup in README.

Progresses #48 