### PR TITLE
Toggle current and peak force group

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -157,4 +157,6 @@ void MainWindow::toggleActions(bool connected) {
     ui->actionStartStop->setEnabled(connected);
     ui->actionConnect->setEnabled(!connected);
     ui->widgetConnection->setEnabled(connected);
+    ui->groupCurrent->setEnabled(connected);
+    ui->groupPeak->setEnabled(connected);
 }


### PR DESCRIPTION
Prevent a access to the serial port if no device is connected.