### PR TITLE
Enable unit change from UI

### DIFF
--- a/src/deviceCommunication/commMaster.cpp
+++ b/src/deviceCommunication/commMaster.cpp
@@ -19,7 +19,7 @@
 /**
  * @file commMaster.cpp
  * @authors Gschwind, Weber, Schoch, Niederberger
- * 
+ *
  * @brief `comm::CommMaster` implementation
  *
  */
@@ -136,6 +136,24 @@ void CommMaster::setNewFreq(int newFreq) {
         case 1280:
             sendData(command::SETSPEED1280);
             break;
+        default:
+            break;
+    }
+}
+void CommMaster::setNewUnit(UnitValue unit) {
+    switch (unit) {
+        case UnitValue::KN:
+            sendData(command::SWITCHTOKN);
+            break;
+
+        case UnitValue::KGF:
+            sendData(command::SWITCHTOKGF);
+            break;
+
+        case UnitValue::LBF:
+            sendData(command::SWITCHTOLBF);
+            break;
+
         default:
             break;
     }

--- a/src/deviceCommunication/commMaster.h
+++ b/src/deviceCommunication/commMaster.h
@@ -97,6 +97,13 @@ class CommMaster : public QObject {
      */
     void setNewFreq(int newFreq);
 
+    /**
+     * @brief Set a new unit on the device
+     * 
+     * @param unit `UnitValue` to switch to
+     */
+    void setNewUnit(UnitValue unit);
+
    signals:
     /**
      * @brief Emit after new sample was sent by a deviceClass

--- a/src/gui/connectionWidget.cpp
+++ b/src/gui/connectionWidget.cpp
@@ -19,7 +19,7 @@
 /**
  * @file connectionWidget.cpp
  * @authors Gschwind, Weber, Schoch, Niederberger
- * 
+ *
  * @brief `ConnectionWidget` implementation
  *
  */
@@ -28,19 +28,23 @@
 #include <QPushButton>
 #include "ui_connectionWidget.h"
 
-ConnectionWidget::ConnectionWidget(QWidget* parent)
-    : QWidget(parent), ui(new Ui::ConnectionWidget) {
+ConnectionWidget::ConnectionWidget(QWidget* parent) : QWidget(parent), ui(new Ui::ConnectionWidget) {
     ui->setupUi(this);
 
-    ui->boxFreq->addItem("10 Hz", int(10));
-    ui->boxFreq->addItem("40 Hz", int(40));
-    ui->boxFreq->addItem("640 Hz", int(640));
-    ui->boxFreq->addItem("1280 Hz", int(1280));
-    ui->boxFreq->setCurrentIndex(-1); // clear box
+    ui->boxFreq->addItem("10 Hz", static_cast<int>(10));
+    ui->boxFreq->addItem("40 Hz", static_cast<int>(40));
+    ui->boxFreq->addItem("640 Hz", static_cast<int>(640));
+    ui->boxFreq->addItem("1280 Hz", static_cast<int>(1280));
+    ui->boxFreq->setCurrentIndex(-1);  // clear box
+
+    ui->boxUnit->addItem("kN", static_cast<int>(UnitValue::KN));
+    ui->boxUnit->addItem("lbf", static_cast<int>(UnitValue::LBF));
+    ui->boxUnit->addItem("kgf", static_cast<int>(UnitValue::KGF));
+    ui->boxUnit->setCurrentIndex(-1);  // clear box
 
     connect(ui->btnRemove, &QPushButton::pressed, this, [=] { communication->removeConnection(); });
-    connect(ui->boxFreq, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
-            &ConnectionWidget::requestNewFreq);
+    connect(ui->boxFreq, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ConnectionWidget::requestNewFreq);
+    connect(ui->boxUnit, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ConnectionWidget::requestNewUnit);
 }
 
 ConnectionWidget::~ConnectionWidget() {
@@ -60,9 +64,19 @@ void ConnectionWidget::requestNewFreq(int index) {
     }
 }
 
+void ConnectionWidget::requestNewUnit(int index) {
+    if (index >= 0 && index < ui->boxUnit->count()) {
+        UnitValue unit = UnitValue(ui->boxUnit->currentData().toInt());
+        if (communication != nullptr) {
+            communication->setNewUnit(unit);
+        }
+    }
+}
+
 void ConnectionWidget::updateWidget(Sample readings) {
     updateBatteryIcon(readings.batteryPercent);
     updateCurrentFrequency(readings.frequency);
+    updateUnit(readings.unitValue);
 }
 
 void ConnectionWidget::updateBatteryIcon(int value) {
@@ -101,7 +115,7 @@ void ConnectionWidget::updateCurrentFrequency(int frequency) {
         case 640:
             indexInComboBox = 2;
             break;
-            
+
         case 1280:
             indexInComboBox = 3;
             break;
@@ -113,4 +127,9 @@ void ConnectionWidget::updateCurrentFrequency(int frequency) {
     if (indexInComboBox < ui->boxFreq->count() && indexInComboBox >= 0) {
         ui->boxFreq->setCurrentIndex(indexInComboBox);
     }
+}
+
+void ConnectionWidget::updateUnit(UnitValue unit) {
+    int index = ui->boxUnit->findData(static_cast<int>(unit));
+    ui->boxUnit->setCurrentIndex(index);
 }

--- a/src/gui/connectionWidget.h
+++ b/src/gui/connectionWidget.h
@@ -42,8 +42,8 @@ class ConnectionWidget;
  * It also enables interaction with a device; e.g. change the frequency or
  * disconnect from a device.
  *
- * @todo Add method to update the remaining data (battery, frequency...)
  * @todo Differentiate between USB and BLE regarding supported frequencies
+ * @todo Lower the update frequency on this widget (1280Hz is way too much...)
  *
  */
 class ConnectionWidget : public QWidget {
@@ -102,6 +102,20 @@ class ConnectionWidget : public QWidget {
      */
     void requestNewFreq(int index);
 
+    /**
+     * @brief Request new unit from the connected device
+     *
+     * Called upon a change on the unit selector. Takes the userdata from
+     * the selector and calls the `comm::CommMaster` instance to request a new unit.
+     *
+     * @note The index sent by QComboBox::currentIndexChanged(int index) will be -1
+     * if the box is empty, which would result in an array out-of-bounds access.
+     * Thus the method does nothing if the index is -1.
+     *
+     * @param index Index of the current item in the unit selector
+     */
+    void requestNewUnit(int index);
+
    private:
     /**
      * @brief Helper function for `updateWidget` to update the battery icon
@@ -123,6 +137,15 @@ class ConnectionWidget : public QWidget {
      * @param frequency Frequency in Hz (10, 40, 640, 1280)
      */
     void updateCurrentFrequency(int frequency);
+
+    /**
+     * @brief Helper function for updateWidget to display the current unit.
+     * 
+     * Updates the comboBox with the current unit.
+     * 
+     * @param unit `UnitValue` of the device.
+     */
+    void updateUnit(UnitValue unit);
     
     Ui::ConnectionWidget* ui;
     comm::CommMaster* communication = nullptr;

--- a/src/gui/connectionWidget.ui
+++ b/src/gui/connectionWidget.ui
@@ -128,6 +128,19 @@
        </widget>
       </item>
       <item>
+       <widget class="QComboBox" name="boxUnit">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         </sizepolicy>
+        </property>
+        <property name="font">
+         <font>
+          <pointsize>9</pointsize>
+         </font>
+        </property>
+       </widget>
+      </item>
+      <item>
        <spacer name="spacerRight">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -116,7 +116,6 @@ void MainWindow::sendSetRelativeZero() {
 void MainWindow::triggerReadings(bool forceStop) {
     statusReading = forceStop ? forceStop : statusReading;
     if (!statusReading) {
-        notification->push("Start reading");
         comm->sendData(command::REQUESTONLINE);
     } else {
         QTimer::singleShot(10, [=] { statusReading = false; });
@@ -126,9 +125,12 @@ void MainWindow::triggerReadings(bool forceStop) {
 }
 
 void MainWindow::receiveNewSample(Sample reading) {
-    statusReading = true;
+    if (!statusReading) {
+        notification->push("Start reading");
+    }
     if (currentUnit != reading.unitValue) {
-        maxValue = 0;  // Trigger reset of peak value to update the unit
+        maxValue = -1000;  // Trigger reset of peak value to update the unit
+        statusReading = true;
         currentUnit = reading.unitValue;
         switch (reading.unitValue) {
             case UnitValue::KN:


### PR DESCRIPTION
The unit should be changeable from the UI. This PR adds a `comboBox` to the connection widget and updates the `CommMaster` to send the appropriate command.

Closes #83 and #20 

<img width="30%" alt="image" src="https://user-images.githubusercontent.com/91913978/225381813-a5acf3d0-2543-4d2e-8e5a-84c9fabefaf9.png">
