### PR TITLE
Add image export feature

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,4 @@
 BasedOnStyle: Chromium
 IndentWidth: '4'
 UseTab: Never
-ColumnLimit: 100
+ColumnLimit: 120

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -68,6 +68,9 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWi
     connect(comm, &comm::CommMaster::newSampleMaster, this, &MainWindow::receiveNewSample);
     connect(comm, &comm::CommMaster::changedStateMaster, this, &MainWindow::toggleActions);
 
+    // Signal from plotWidget
+    connect(ui->widgetChart, &Plot::stopHardware, this, [=]{triggerReadings(true);});
+
     // disable wait for close, automatic close after main window close
     dAbout->setAttribute(Qt::WA_QuitOnClose, false);
     dDebug->setAttribute(Qt::WA_QuitOnClose, false);
@@ -110,7 +113,8 @@ void MainWindow::sendSetRelativeZero() {
     comm->sendData(command::SETZERO);
 }
 
-void MainWindow::triggerReadings() {
+void MainWindow::triggerReadings(bool forceStop) {
+    statusReading = forceStop ? forceStop : statusReading;
     if (!statusReading) {
         notification->push("Start reading");
         comm->sendData(command::REQUESTONLINE);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -19,15 +19,13 @@
 /**
  * @file mainwindow.cpp
  * @authors Gschwind, Weber, Schoch, Niederberger
- * 
+ *
  * @brief `MainWindow` implementation
  *
  */
 
 #include "mainwindow.h"
 #include <QDesktopServices>
-#include <QFileDialog>
-#include <QStandardPaths>
 #include <QTimer>
 #include "../deviceCommunication/command.h"
 #include "../notification/notification.h"
@@ -53,6 +51,7 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWi
     connect(ui->actionShowLog, &QAction::triggered, this, &MainWindow::showLog);
     connect(ui->actionClearLog, &QAction::triggered, notification, &Notification::clear);
     connect(ui->actionSaveLog, &QAction::triggered, notification, &Notification::saveLog);
+    connect(ui->actionAsPng, &QAction::triggered, this, [=] { ui->widgetChart->saveImage(notification); });
 
     // Tool bar actions
     connect(ui->actionConnect, &QAction::triggered, dConnect, &DialogConnect::show);
@@ -123,8 +122,8 @@ void MainWindow::triggerReadings() {
 
 void MainWindow::receiveNewSample(Sample reading) {
     statusReading = true;
-    if(currentUnit != reading.unitValue) {
-        maxValue = 0; // Trigger reset of peak value to update the unit
+    if (currentUnit != reading.unitValue) {
+        maxValue = 0;  // Trigger reset of peak value to update the unit
         currentUnit = reading.unitValue;
         switch (reading.unitValue) {
             case UnitValue::KN:

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -41,6 +41,7 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWi
     dDebug = new DialogDebug(comm, this);
     dConnect = new DialogConnect(comm, this);
     ui->widgetConnection->setCommunicationMaster(comm);
+    ui->widgetChart->attachNotification(notification);
 
     // menu actions
     connect(ui->actionAbout_Qt, &QAction::triggered, qApp, &QApplication::aboutQt);
@@ -51,7 +52,7 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWi
     connect(ui->actionShowLog, &QAction::triggered, this, &MainWindow::showLog);
     connect(ui->actionClearLog, &QAction::triggered, notification, &Notification::clear);
     connect(ui->actionSaveLog, &QAction::triggered, notification, &Notification::saveLog);
-    connect(ui->actionAsPng, &QAction::triggered, this, [=] { ui->widgetChart->saveImage(notification); });
+    connect(ui->actionAsPng, &QAction::triggered, ui->widgetChart, &Plot::saveImage);
 
     // Tool bar actions
     connect(ui->actionConnect, &QAction::triggered, dConnect, &DialogConnect::show);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -52,7 +52,7 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWi
     connect(ui->actionShowLog, &QAction::triggered, this, &MainWindow::showLog);
     connect(ui->actionClearLog, &QAction::triggered, notification, &Notification::clear);
     connect(ui->actionSaveLog, &QAction::triggered, notification, &Notification::saveLog);
-    connect(ui->actionAsPng, &QAction::triggered, ui->widgetChart, &Plot::saveImage);
+    connect(ui->actionSaveImage, &QAction::triggered, ui->widgetChart, &Plot::saveImage);
 
     // Tool bar actions
     connect(ui->actionConnect, &QAction::triggered, dConnect, &DialogConnect::show);

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -135,9 +135,6 @@ class MainWindow : public QMainWindow {
     void triggerReadings();
 
    private:
-    void updateImportantValues(float time, float value);
-
-   private:
     Ui::MainWindow* ui;
     comm::CommMaster* comm;
     DialogAbout* dAbout;

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -40,7 +40,7 @@
 QT_BEGIN_NAMESPACE
 /**
  * @brief Namespace for all GUI elements
- * 
+ *
  */
 namespace Ui {
 class MainWindow;
@@ -49,7 +49,7 @@ QT_END_NAMESPACE
 
 /**
  * @brief Main window for the application linescaleGUI
- * 
+ *
  */
 class MainWindow : public QMainWindow {
     Q_OBJECT
@@ -131,8 +131,10 @@ class MainWindow : public QMainWindow {
      * `MainWindow::receiveNewSample`.
      * If the host terminates the stream, the bool will be set to false after
      * a delay. This is to prevent buffered data from setting the bool to true.
+     *
+     * @param forceStop If set to true, the connection is paused regardless of the current state.
      */
-    void triggerReadings();
+    void triggerReadings(bool forceStop = false);
 
    private:
     Ui::MainWindow* ui;

--- a/src/gui/mainwindow.ui
+++ b/src/gui/mainwindow.ui
@@ -402,13 +402,7 @@
     <property name="title">
      <string>File</string>
     </property>
-    <widget class="QMenu" name="menuSavePlot">
-     <property name="title">
-      <string>Save plot</string>
-     </property>
-     <addaction name="actionAsPng"/>
-    </widget>
-    <addaction name="menuSavePlot"/>
+    <addaction name="actionSaveImage"/>
     <addaction name="actionExit"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
@@ -540,9 +534,9 @@
     <string>Connect to a device</string>
    </property>
   </action>
-  <action name="actionAsPng">
+  <action name="actionSaveImage">
    <property name="text">
-    <string>image (png)</string>
+    <string>Save image</string>
    </property>
   </action>
  </widget>

--- a/src/gui/mainwindow.ui
+++ b/src/gui/mainwindow.ui
@@ -402,6 +402,13 @@
     <property name="title">
      <string>File</string>
     </property>
+    <widget class="QMenu" name="menuSavePlot">
+     <property name="title">
+      <string>Save plot</string>
+     </property>
+     <addaction name="actionAsPng"/>
+    </widget>
+    <addaction name="menuSavePlot"/>
     <addaction name="actionExit"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
@@ -484,6 +491,9 @@
    <property name="text">
     <string>StartStop</string>
    </property>
+   <property name="shortcut">
+    <string>Space</string>
+   </property>
   </action>
   <action name="actionDisconnect">
    <property name="icon">
@@ -528,6 +538,11 @@
    </property>
    <property name="toolTip">
     <string>Connect to a device</string>
+   </property>
+  </action>
+  <action name="actionAsPng">
+   <property name="text">
+    <string>image (png)</string>
    </property>
   </action>
  </widget>

--- a/src/gui/plotWidget.cpp
+++ b/src/gui/plotWidget.cpp
@@ -25,6 +25,8 @@
 
 #include "plotWidget.h"
 #include <QDebug>
+#include <QFileDialog>
+#include <QStandardPaths>
 
 Plot::Plot(QWidget* parent) : QWidget(parent) {
     updateTimer = new QTimer(this);
@@ -41,8 +43,8 @@ Plot::Plot(QWidget* parent) : QWidget(parent) {
     // customPlot->setOpenGl(true); @todo Fix HiDPI bug in QCustomPlot library.
     customPlot->setNoAntialiasingOnDrag(true);
 
-    customPlot->setInteractions(QCP::iRangeDrag | QCP::iRangeZoom | QCP::iSelectAxes |
-                                QCP::iSelectPlottables | QCP::iMultiSelect);
+    customPlot->setInteractions(QCP::iRangeDrag | QCP::iRangeZoom | QCP::iSelectAxes | QCP::iSelectPlottables |
+                                QCP::iMultiSelect);
     customPlot->xAxis->setLabel("");
     customPlot->yAxis->setLabel("");
     customPlot->legend->setVisible(false);
@@ -200,14 +202,11 @@ void Plot::contextMenuRequest(QPoint pos) {
     bool clickedOnAxis = false;
     if (auto val = customPlot->yAxis->selectTest(pos, true); val > 0 && val < selectionTol) {
         clearSelection();
-        customPlot->yAxis->setSelectedParts(QCPAxis::spAxis | QCPAxis::spAxisLabel |
-                                            QCPAxis::spTickLabels);
+        customPlot->yAxis->setSelectedParts(QCPAxis::spAxis | QCPAxis::spAxisLabel | QCPAxis::spTickLabels);
         clickedOnAxis = true;
-    } else if (auto val2 = customPlot->xAxis->selectTest(pos, true);
-               val2 > 0 && val2 < selectionTol) {
+    } else if (auto val2 = customPlot->xAxis->selectTest(pos, true); val2 > 0 && val2 < selectionTol) {
         clearSelection();
-        customPlot->xAxis->setSelectedParts(QCPAxis::spAxis | QCPAxis::spAxisLabel |
-                                            QCPAxis::spTickLabels);
+        customPlot->xAxis->setSelectedParts(QCPAxis::spAxis | QCPAxis::spAxisLabel | QCPAxis::spTickLabels);
         clickedOnAxis = true;
     }
     if (!clickedOnAxis && customPlot->selectedGraphs().length() > 0) {
@@ -314,4 +313,15 @@ void Plot::convertToNewUnit(UnitValue nextUnit) {
     }
 
     currentUnit = nextUnit;
+}
+
+void Plot::saveImage(Notification* notification) {
+    QString desktopPath = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
+    QString filename = QFileDialog::getSaveFileName(this, tr("Save file"), desktopPath + tr("/LineScale3.png"), ".png");
+    if (filename != "") {
+        customPlot->grab().save(filename);
+        notification->push(tr("Saved as ") + filename, Notification::SEVERITY_INFO);
+    } else {
+        notification->push(tr("Invalid file name"), Notification::SEVERITY_WARNING);
+    }
 }

--- a/src/gui/plotWidget.cpp
+++ b/src/gui/plotWidget.cpp
@@ -90,6 +90,10 @@ Plot::Plot(QWidget* parent) : QWidget(parent) {
     autoShowNewestAction->setChecked(true);
     addAction(autoShowNewestAction);
 
+    saveImageAction = new QAction("Save as image", this);
+    connect(saveImageAction, &QAction::triggered, this, &Plot::saveImage);
+    addAction(saveImageAction);
+
     clearSelectionAction = new QAction("Clear selection", this);
     clearSelectionAction->setShortcut(QKeySequence::Cancel);
     connect(clearSelectionAction, &QAction::triggered, this, &Plot::clearSelection);
@@ -221,6 +225,9 @@ void Plot::contextMenuRequest(QPoint pos) {
         menu->addAction(autoShowNewestAction);
     }
 
+    menu->addSeparator();
+    menu->addAction(saveImageAction);
+
     menu->popup(customPlot->mapToGlobal(pos));
 }
 
@@ -315,13 +322,22 @@ void Plot::convertToNewUnit(UnitValue nextUnit) {
     currentUnit = nextUnit;
 }
 
-void Plot::saveImage(Notification* notification) {
+void Plot::saveImage() {
     QString desktopPath = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
     QString filename = QFileDialog::getSaveFileName(this, tr("Save file"), desktopPath + tr("/LineScale3.png"), ".png");
+
     if (filename != "") {
         customPlot->grab().save(filename);
+    }
+
+    if (notification && filename != "") {
         notification->push(tr("Saved as ") + filename, Notification::SEVERITY_INFO);
-    } else {
+    }
+    else if(notification) {
         notification->push(tr("Invalid file name"), Notification::SEVERITY_WARNING);
     }
+}
+
+void Plot::attachNotification(Notification* _notification) {
+    this->notification = _notification;
 }

--- a/src/gui/plotWidget.cpp
+++ b/src/gui/plotWidget.cpp
@@ -24,7 +24,6 @@
  */
 
 #include "plotWidget.h"
-#include <QDebug>
 #include <QFileDialog>
 #include <QStandardPaths>
 
@@ -323,6 +322,8 @@ void Plot::convertToNewUnit(UnitValue nextUnit) {
 }
 
 void Plot::saveImage() {
+    emit stopHardware(); // Pause any connection
+
     QString desktopPath = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
     QString filename = QFileDialog::getSaveFileName(this, tr("Save file"), desktopPath + tr("/LineScale3.png"), ".png");
 

--- a/src/gui/plotWidget.h
+++ b/src/gui/plotWidget.h
@@ -99,9 +99,15 @@ class Plot : public QWidget {
     /**
      * @brief Save the current plot window as png to the local machine
      *
-     * @param notification Pointer to send some outputs to the user
      */
-    void saveImage(Notification* notification);
+    void saveImage();
+
+    /**
+     * @brief Attach a notification instance to the plot widget to notify the user.
+     *
+     * @param notification Pointer to the notification instance
+     */
+    void attachNotification(Notification* notification);
 
    private slots:
     /**
@@ -187,6 +193,9 @@ class Plot : public QWidget {
     QAction* autoRangeAction;
     QAction* autoShowNewestAction;
     QAction* clearSelectionAction;
+    QAction* saveImageAction;
+
+    Notification* notification = nullptr;
 
     static constexpr double factorKnToLbf = 224.8089431;  ///< Convert from kN to lbf
     static constexpr double factorKnToKgf = 101.9716213;  ///< Convert from kN to kgf

--- a/src/gui/plotWidget.h
+++ b/src/gui/plotWidget.h
@@ -35,7 +35,7 @@
 #include "../notification/notification.h"
 #include "../parser/parser.h"
 
-// @todo Better way to disable this warning for MSVC.
+/// @todo Better way to disable this warning for MSVC.
 #if _MSC_VER && !__INTEL_COMPILER
 #pragma warning(push)
 #pragma warning(disable : 4127)

--- a/src/gui/plotWidget.h
+++ b/src/gui/plotWidget.h
@@ -28,6 +28,13 @@
 #ifndef PLOTWIDGET_H_
 #define PLOTWIDGET_H_
 
+#include <QTimer>
+#include <QVector>
+#include <QWidget>
+
+#include "../notification/notification.h"
+#include "../parser/parser.h"
+
 // @todo Better way to disable this warning for MSVC.
 #if _MSC_VER && !__INTEL_COMPILER
 #pragma warning(push)
@@ -38,18 +45,11 @@
 #include <QCustomPlot/qcustomplot.h>
 #endif
 
-#include <QTimer>
-#include <QVector>
-#include <QWidget>
-
-#include "../parser/parser.h"
-
 /**
  * @brief Widget to display a dynamic line graph chart.
  *
  * @todo Allow to zoom with panning (touchscreen).
  * @todo Maybe implement custom range dialog.
- * @todo Implement saving the graph as image.
  */
 class Plot : public QWidget {
    public:
@@ -95,6 +95,13 @@ class Plot : public QWidget {
      *                        time of the previous graph.
      */
     void beginNewGraph(bool startFromOrigin = true);
+
+    /**
+     * @brief Save the current plot window as png to the local machine
+     *
+     * @param notification Pointer to send some outputs to the user
+     */
+    void saveImage(Notification* notification);
 
    private slots:
     /**

--- a/src/gui/plotWidget.h
+++ b/src/gui/plotWidget.h
@@ -52,6 +52,8 @@
  * @todo Maybe implement custom range dialog.
  */
 class Plot : public QWidget {
+    Q_OBJECT
+
    public:
     /**
      * @brief Create a new Plot widget.
@@ -99,6 +101,9 @@ class Plot : public QWidget {
     /**
      * @brief Save the current plot window as png to the local machine
      *
+     * Uses the native file dialogue box to select the save location. The resolution
+     * and aspect ratio will be the same as the current plot widget.
+     *
      */
     void saveImage();
 
@@ -142,8 +147,9 @@ class Plot : public QWidget {
      * @param plottable The plottable that was clicked.
      * @param dataIndex The nearest data point index to the click position.
      * @param event The actual mouse event of the click.
+     * @todo Create implementation
      */
-    void graphClicked(QCPAbstractPlottable* plottable, int dataIndex, QMouseEvent* event);
+    // void graphClicked(QCPAbstractPlottable* plottable, int dataIndex, QMouseEvent* event);
 
     /**
      * @brief Replot the graph possibly changing the axis ranges.
@@ -177,6 +183,13 @@ class Plot : public QWidget {
      * @param next The next unit
      */
     void convertToNewUnit(UnitValue next);
+
+   signals:
+    /**
+     * @brief Emit before saving a plot. Prevent simultaneous export and new data acquisition
+     *
+     */
+    void stopHardware(void);
 
    private:
     QCustomPlot* customPlot;

--- a/src/notification/notification.cpp
+++ b/src/notification/notification.cpp
@@ -19,18 +19,18 @@
 /**
  * @file notification.cpp
  * @authors Gschwind, Weber, Schoch, Niederberger
- * 
+ *
  * @brief `Notification` implementation
  *
  */
 
 #include "notification.h"
-#include <iostream>
-#include <fstream>
-#include <filesystem>
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QTime>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
 
 const QString Notification::stringColorStart[] = {
     "",
@@ -56,18 +56,18 @@ const QString Notification::stringSeverity[] = {
 Notification::Notification(QTextBrowser* textBrowser) : textBrowser(textBrowser) {}
 
 bool Notification::push(const QString& message, Severity severity, bool showDialog) {
-    if ((textBrowser == nullptr) || (severity < SEVERITY_NONE) || (severity > SEVERITY_ERROR)) {
+    if ((textBrowser == nullptr) || (severity < SEVERITY_NONE) || (severity > SEVERITY_CRITICAL)) {
         return false;
     }
 
     QTime time = QTime::currentTime();
-    QString string = stringColorStart[severity] + time.toString() + stringSeverity[severity] +
-                     ": " + stringColorEnd[severity] + message;
+    QString string = stringColorStart[severity] + time.toString() + stringSeverity[severity] + ": " +
+                     stringColorEnd[severity] + message;
     textBrowser->append(string);
 
-    if ((severity == SEVERITY_ERROR) && (showDialog == true)) {
-        QMessageBox::critical(textBrowser->parentWidget(), stringSeverity[severity], message,
-                              QMessageBox::Cancel, QMessageBox::Cancel);
+    if ((severity == SEVERITY_CRITICAL) && (showDialog == true)) {
+        QMessageBox::critical(textBrowser->parentWidget(), stringSeverity[severity], message, QMessageBox::Cancel,
+                              QMessageBox::Cancel);
     }
 
     return true;
@@ -87,9 +87,8 @@ bool Notification::saveLog(void) {
         return false;
     }
 
-    QString fileName = QFileDialog::getSaveFileName(
-        textBrowser->parentWidget(), "", "Log",
-        "Text File (*.txt)\n Markdown File (*.md)\nHTML File (*.html)");
+    QString fileName = QFileDialog::getSaveFileName(textBrowser->parentWidget(), "", "Log",
+                                                    "Text File (*.txt)\n Markdown File (*.md)\nHTML File (*.html)");
     std::ofstream file(fileName.toStdString());
 
     if (!file.is_open()) {

--- a/src/notification/notification.h
+++ b/src/notification/notification.h
@@ -44,7 +44,7 @@ class Notification : public QObject {
         SEVERITY_NONE,     ///< No severity level is shown
         SEVERITY_INFO,     ///< Severity level info
         SEVERITY_WARNING,  ///< Severity level warning with colored text
-        SEVERITY_ERROR     ///< Severity level error with colored text and optional error dialog
+        SEVERITY_CRITICAL  ///< Severity level critical with colored text and optional error dialog
     };
 
     /**
@@ -59,7 +59,7 @@ class Notification : public QObject {
      *          browser
      * @param   message Message which shall be written
      * @param   severity Severity level of the notification
-     * @param   showDialog Only applies to SEVERITY_ERROR levels. By setting
+     * @param   showDialog Only applies to SEVERITY_CRITICAL levels. By setting
      *          this parameter to false, the error dialog will not be shown.
      * @return  Returns false if an error occurred. True otherwise.
      */


### PR DESCRIPTION
- [x] #77 

Add the ability to export the current plot as png, pdf and jpg. The export is done within the `Plot` module and is triggered by either a menu action or a right click within the plot widget itself.

This PR also fixes two minor issues: 
- [x] #85 Rename the conflicting enum
- [x] #81 Add space as keyboard shortcut to start/stop the data flow