### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,113 @@
+name: Release
+
+on: workflow_dispatch
+
+jobs:
+  build:
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - {
+            name: "Windows Latest MSVC",
+            os: windows-latest,
+            build_type: "Release", generator: "Visual Studio 17 2022",
+            qt_archives: "qttools"
+          }
+        - {
+            name: "Ubuntu 20.04 Clang", # for generating compatible packages
+            os: ubuntu-20.04,
+            # cc: "gcc", cxx: "g++", generator: "Unix Makefiles",
+            build_type: "Release", cc: "clang", cxx: "clang++", generator: "Unix Makefiles",
+            ldflags: "-fuse-ld=lld", qt_archives: "icu"
+          }
+        # TODO: make this working
+        # - {
+        #     name: "macOS Latest Clang",
+        #     os: macos-latest,
+        #     build_type: "Release", cc: "clang", cxx: "clang++", generator: "Unix Makefiles",
+        #     qt_archives: ""
+        #   }
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v3
+        with:
+          version: '5.15.2'
+          target: 'desktop'
+          dir: '${{ github.workspace }}'
+          install-deps: 'true'
+          modules: ''
+          archives: 'qtbase qtconnectivity qtserialport ${{ matrix.config.qt_archives }}'
+          cache: 'true'
+          cache-key-prefix: 'install-qt-action'
+          tools: 'tools_ifw'
+          extra: '--external 7z'
+
+      - name: Set up environment variables
+        shell: bash
+        run: |
+          echo "QT_DIR=$Qt5_DIR" >> $GITHUB_ENV
+          [[ -n "${{ matrix.config.cc }}" ]] \
+            && echo "CC=${{ matrix.config.cc }}" >> $GITHUB_ENV || true
+          [[ -n "${{ matrix.config.cxx }}" ]] \
+            && echo "CXX=${{ matrix.config.cxx }}" >> $GITHUB_ENV || true
+          [[ -n "${{ matrix.config.ldflags }}" ]] \
+            && echo "LDFLAGS=${{ matrix.config.ldflags }}" >> $GITHUB_ENV || true
+      
+      - name: Set up Linux packaging tools
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          sudo apt-get -y install libgl1-mesa-dev libpulse-dev libxcb-glx0 libxcb-icccm4 \
+            libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-render0 \
+            libxcb-shape0 libxcb-shm0 libxcb-sync1 libxcb-util1 libxcb-xfixes0 \
+            libxcb-xinerama0 libxcb1 libxkbcommon-dev libxcb-xkb-dev libxcb-image0 \
+            libxcb-keysyms1 libxcb-render-util0 libxcb-xkb1 libxkbcommon-x11-0
+          wget -P ${QT_DIR}/bin https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20220822-1/linuxdeploy-x86_64.AppImage
+          wget -P ${QT_DIR}/bin https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage
+          chmod u+x ${QT_DIR}/bin/linuxdeploy-x86_64.AppImage
+          chmod u+x ${QT_DIR}/bin/linuxdeploy-plugin-qt-x86_64.AppImage
+      - name: Configure
+        shell: bash
+        run: |
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} \
+            -G "${{ matrix.config.generator }}" -DWARNINGS_AS_ERRORS=
+
+      - name: Build
+        shell: bash
+        run: |
+          cmake --build build --config ${{ matrix.config.build_type }}
+      
+      - name: Generate packages Windows
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          cpack -G ZIP --config build/BundleConfig.cmake
+          cpack -G IFW --config build/BundleConfig.cmake || true
+      - name: Generate packages Linux
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          cpack -G External --config build/BundleConfig.cmake
+      - name: Upload artifacts Windows
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v3
+        with:
+          name: binaries-win
+          path: |
+            build/linescaleGUI-*.zip
+            build/linescaleGUI-*.exe
+          retention-days: 1
+      - name: Upload artifacts Linux
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@v3
+        with:
+          name: binaries-linux
+          path: |
+            build/linescaleGUI*.AppImage
+          retention-days: 1

--- a/tools/cmake/CPackLinuxDeployQt.cmake.in
+++ b/tools/cmake/CPackLinuxDeployQt.cmake.in
@@ -1,3 +1,3 @@
 execute_process(COMMAND ${CMAKE_COMMAND} --install . --prefix=${CPACK_PACKAGE_DIRECTORY}/_CPack_Packages/Linux/External/AppImage
                 WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-	execute_process(COMMAND env QMAKE=${qmake_executable} "${LINUXDEPLOY_EXECUTABLE}" --plugin=qt --output=appimage --appdir=${CPACK_PACKAGE_DIRECTORY}/_CPack_Packages/Linux/External/AppImage -e ${CMAKE_BINARY_DIR}/${target} -d ${assets_dir}/app/linescaleGUI.desktop  -i ${assets_dir}/app/linescaleGUI.png WORKING_DIRECTORY ${CPACK_PACKAGE_DIRECTORY})
+execute_process(COMMAND env QMAKE=${qmake_executable} "${LINUXDEPLOY_EXECUTABLE}" --plugin=qt --output=appimage --appdir=${CPACK_PACKAGE_DIRECTORY}/_CPack_Packages/Linux/External/AppImage -e ${CMAKE_BINARY_DIR}/${target} -d ${assets_dir}/app/linescaleGUI.desktop -i ${assets_dir}/app/linescaleGUI.png WORKING_DIRECTORY ${CPACK_PACKAGE_DIRECTORY})


### PR DESCRIPTION
Adds a release workflow that generates packages for Windows and Linux, currently:
- `.zip` and Qt installer framework (`.exe`) for Windows
- `.AppImage` for Linux

The generated artifacts are currently not uploaded to a release but are available on the artifacts section of the workflow run, stored for 1 day (configurable).

### TODO
- [ ] Implement more packages for Linux (rpm and deb).
- [ ] Implement packaging for macOS.